### PR TITLE
add openmpi-3.1.3 with python

### DIFF
--- a/HPC/openmpi-python/Dockerfile
+++ b/HPC/openmpi-python/Dockerfile
@@ -1,0 +1,4 @@
+FROM ethcscs/openmpi:3.1.3
+
+RUN apt-get update && apt-get -y install python3 python3-pip python3-dev --no-install-recommends
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This PR adds Dockerfile derived from ethcscs/openmpi:3.1.3 with python3 installed.